### PR TITLE
Update to Elm 0.19.1; fix tests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -20,5 +20,7 @@
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "generate-tests": "node ./generate-tests.js draft-6 > tests/Draft6.elm && node ./generate-tests.js draft-4 > tests/Draft4.elm"
   },
   "devDependencies": {
-    "elm": "^0.18.0",
-    "elm-live": "^2.7.4",
-    "elm-test": "^0.18.7"
+    "elm": "^0.19.1-5",
+    "elm-live": "^4.0.2",
+    "elm-test": "^0.19.1"
   },
   "dependencies": {
+    "elm-format": "^0.8.5",
     "gh-pages": "^1.0.0"
   }
 }

--- a/src/Json/Schema.elm
+++ b/src/Json/Schema.elm
@@ -28,8 +28,7 @@ import Json.Decode exposing (Value, decodeString, decodeValue)
 import Json.Schema.Definitions exposing (Schema, decoder)
 import Json.Schema.Helpers exposing (collectIds)
 import Json.Schema.Validation exposing (Error, JsonPointer, ValidationError(..), ValidationOptions, validate)
-import Json.Schemata
-import Ref exposing (SchemataPool, defaultPool)
+import Ref
 
 
 {-| Validate value against JSON Schema. Returns Result with updated value in case if validationOptions require so.
@@ -42,7 +41,7 @@ validateValue : ValidationOptions -> Value -> Schema -> Result (List Error) Valu
 validateValue validationOptions value schema =
     let
         ( pool, _ ) =
-            collectIds schema defaultPool
+            collectIds schema Ref.defaultPool
     in
     validate validationOptions pool value schema schema
 
@@ -53,10 +52,10 @@ validateAt : ValidationOptions -> Value -> Schema -> String -> Result (List Erro
 validateAt validationOptions value schema uri =
     let
         ( pool, _ ) =
-            collectIds schema defaultPool
+            collectIds schema Ref.defaultPool
     in
     case Ref.resolveReference "" pool schema uri of
-        Just ( ns, resolvedSchema ) ->
+        Just ( _, resolvedSchema ) ->
             validate validationOptions pool value schema resolvedSchema
 
         Nothing ->

--- a/src/Json/Schema/Builder.elm
+++ b/src/Json/Schema/Builder.elm
@@ -179,7 +179,7 @@ validate validationOptions val sb =
         Ok schema ->
             Validation.validate validationOptions Ref.defaultPool val schema schema
 
-        Err s ->
+        Err _ ->
             Ok val
 
 
@@ -621,12 +621,11 @@ exclusiveBoundaryToString eb =
 
 boolToString : Bool -> String
 boolToString b =
-    case b of
-        True ->
-            "true"
+    if b then
+        "true"
 
-        False ->
-            "false"
+    else
+        "false"
 
 
 {-| Encode schema into a builder code (elm)

--- a/src/Json/Schema/Definitions.elm
+++ b/src/Json/Schema/Definitions.elm
@@ -29,9 +29,9 @@ Feel free to open [issue](https://github.com/1602/json-schema) to describe your 
 -}
 
 import Json.Decode as Decode exposing (Decoder, Value, andThen, bool, fail, field, float, int, lazy, list, nullable, string, succeed, value)
-import Json.Decode.Pipeline as DecodePipeline exposing (optional, optionalAt, required, requiredAt)
+import Json.Decode.Pipeline as DecodePipeline exposing (optional, requiredAt)
 import Json.Encode as Encode
-import Util exposing (foldResults, isInt, resultToDecoder)
+import Util exposing (foldResults, resultToDecoder)
 
 
 {-| Schema can be either boolean or actual object containing validation and meta properties
@@ -180,10 +180,6 @@ blankSubSchema =
     , not = Nothing
     , source = Encode.object []
     }
-
-
-type RowEncoder a
-    = RowEncoder (Maybe a) String (a -> Value)
 
 
 {-| -}
@@ -591,6 +587,7 @@ singleTypeDecoder s =
 schemataDecoder : Decoder Schemata
 schemataDecoder =
     Decode.keyValuePairs (lazy (\_ -> decoder))
+        |> Decode.andThen (\x -> succeed <| List.reverse x)
         |> Decode.map Schemata
 
 

--- a/src/Json/Schema/Examples.elm
+++ b/src/Json/Schema/Examples.elm
@@ -1,6 +1,5 @@
 module Json.Schema.Examples exposing (bookingSchema, coreSchemaDraft6)
 
-import Json.Decode
 import Json.Encode as Encode
 import Json.Schema.Builder exposing (..)
 import Json.Schema.Definitions exposing (Schema, blankSchema)
@@ -50,7 +49,7 @@ coreSchemaDraft6 =
             , ( "stringArray"
               , buildSchema
                     |> withType "array"
-                    |> withDefault ([] |> Encode.list)
+                    |> withDefault (Encode.list Encode.object [])
                     |> withItem (buildSchema |> withType "string")
               )
             ]

--- a/src/Json/Schema/Helpers.elm
+++ b/src/Json/Schema/Helpers.elm
@@ -14,8 +14,8 @@ module Json.Schema.Helpers exposing
 
     )
 
-import Dict exposing (Dict)
-import Json.Decode as Decode exposing (Value, decodeString, decodeValue)
+import Dict
+import Json.Decode as Decode
 import Json.Encode as Encode
 import Json.Schema.Definitions as Schema
     exposing
@@ -25,10 +25,8 @@ import Json.Schema.Definitions as Schema
         , SingleType(..)
         , SubSchema
         , Type(..)
-        , blankSchema
-        , blankSubSchema
         )
-import Ref exposing (SchemataPool, parseJsonPointer, resolveReference)
+import Ref exposing (SchemataPool, parseJsonPointer)
 
 
 type alias ImpliedType =
@@ -169,40 +167,6 @@ makeJsonPointer ( isPointer, ns, path ) =
                            }
 
 -}
-
-
-getListItem : Int -> List a -> Maybe a
-getListItem index list =
-    let
-        ( _, result ) =
-            List.foldl
-                (\item ( i, resultLocal ) ->
-                    if index == i then
-                        ( i + 1, Just item )
-
-                    else
-                        ( i + 1, resultLocal )
-                )
-                ( 0, Nothing )
-                list
-    in
-    result
-
-
-setListItem : Int -> a -> List a -> List a
-setListItem index a list =
-    List.indexedMap
-        (\i item ->
-            if index == i then
-                a
-
-            else
-                item
-        )
-        list
-
-
-
 {-
    calcSubSchemaType : Maybe Value -> Schema -> SubSchema -> Maybe ( Type, SubSchema )
    calcSubSchemaType actualValue schema os =
@@ -395,26 +359,6 @@ setListItem index a list =
                )
                Nothing
 -}
-
-
-encodeDict : Dict String Value -> Value
-encodeDict dict =
-    Encode.object (Dict.toList dict)
-
-
-decodeDict : Value -> Dict String Value
-decodeDict val =
-    Decode.decodeValue (Decode.dict Decode.value) val
-        |> Result.withDefault Dict.empty
-
-
-decodeList : Value -> List Value
-decodeList val =
-    Decode.decodeValue (Decode.list Decode.value) val
-        |> Result.withDefault []
-
-
-
 {-
    getDefinition : Maybe Schemata -> String -> Maybe Schema
    getDefinition defs name =
@@ -478,7 +422,7 @@ collectIds schema pool =
             case uri of
                 Just s ->
                     let
-                        ( isPointer, ns, _ ) =
+                        ( _, ns, _ ) =
                             parseJsonPointer s ""
                     in
                     ns
@@ -486,7 +430,7 @@ collectIds schema pool =
                 Nothing ->
                     ""
 
-        manageId : String -> Value -> SchemataPool -> List ( String, Value ) -> ( List ( String, Value ), ( SchemataPool, String ) )
+        manageId : String -> Encode.Value -> SchemataPool -> List ( String, Encode.Value ) -> ( List ( String, Encode.Value ), ( SchemataPool, String ) )
         manageId ns source poolLocal obj =
             case List.filter (\( name, _ ) -> name == "id" || name == "$id") obj of
                 ( _, val ) :: _ ->
@@ -515,7 +459,7 @@ collectIds schema pool =
                 |> Decode.decodeValue (Decode.keyValuePairs Decode.value)
                 |> Result.withDefault []
                 |> manageId ns source poolLocal
-                |> (\( list, res ) -> List.foldl (\( key, val ) -> walkValue val) res list)
+                |> (\( list, res ) -> List.foldl (\( _, val ) -> walkValue val) res list)
     in
     case schema of
         ObjectSchema { id, source } ->

--- a/src/Json/Schema/Random.elm
+++ b/src/Json/Schema/Random.elm
@@ -20,7 +20,6 @@ Experimental module.
 -}
 
 import Char
-import Dict
 import Json.Encode as Encode exposing (Value)
 import Json.Schema.Definitions
     exposing
@@ -31,7 +30,7 @@ import Json.Schema.Definitions
         , Type(..)
         )
 import Json.Schema.Helpers exposing (collectIds)
-import Random exposing (Generator, Seed)
+import Random exposing (Generator)
 import Ref exposing (defaultPool)
 import Util exposing (getAt, uncons)
 
@@ -223,13 +222,6 @@ valueAt settings s ref =
     let
         ( pool, ns ) =
             collectIds s defaultPool
-
-        --|> Debug.log "pool is"
-        a =
-            pool
-                |> Dict.keys
-
-        -- |> Debug.log "pool keys are"
     in
     case Ref.resolveReference ns pool s ref of
         Just ( nsLocal, ss ) ->
@@ -267,14 +259,14 @@ valueGenerator settings ns pool schema =
         Nothing ->
             nullGenerator
 
-        Just ( nsLocal, BooleanSchema b ) ->
+        Just ( _, BooleanSchema b ) ->
             if b then
                 randomBool |> Random.map (\_ -> Encode.object [])
 
             else
                 randomBool |> Random.map (\_ -> Encode.null)
 
-        Just ( nsLocal, ObjectSchema os ) ->
+        Just ( _, ObjectSchema os ) ->
             [ Maybe.andThen uncons os.examples
                 |> Maybe.map randomItemFromList
             , Maybe.andThen uncons os.enum

--- a/src/Ref.elm
+++ b/src/Ref.elm
@@ -158,19 +158,10 @@ resolveReference ns pool schema ref =
         resolveRecursively namespace limit localSchema localRef =
             let
                 ( isPointer, localNs, path ) =
-                    parseJsonPointer {- Debug.log "resolving ref" -} localRef namespace
+                    parseJsonPointer localRef namespace
 
-                --|> Debug.log "new json pointer (parsed)"
-                --|> Debug.log ("parse " ++ (toString localRef) ++ " within ns " ++ (toString namespace))
                 newJsonPointer =
                     makeJsonPointer ( isPointer, localNs, path )
-
-                --|> Debug.log "new json pointer (combined)"
-                a =
-                    pool
-                        |> Dict.keys
-
-                --|> Debug.log "pool keys"
             in
             if limit > 0 then
                 if isPointer then

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -7,7 +7,7 @@ foldResults : List (Result x y) -> Result x (List y)
 foldResults results =
     results
         |> List.foldl
-            (\t -> Result.andThen (\r -> t |> Result.map (\a -> (::) a r)))
+            (\t -> Result.andThen (\r -> t |> Result.map (\a -> a :: r)))
             (Ok [])
         |> Result.map List.reverse
 

--- a/tests/Decoding.elm
+++ b/tests/Decoding.elm
@@ -1,36 +1,41 @@
 module Decoding exposing (all)
 
-import Test exposing (Test, describe, test, only, skip)
+import Expect
+import Json.Decode as Decode
+import Json.Encode as Encode exposing (Value)
 import Json.Schema.Builder
     exposing
         ( SchemaBuilder
-        , buildSchema
         , boolSchema
+        , buildSchema
         , toSchema
-        , withType
-        , withNullableType
-        , withUnionType
-        , withContains
-        , withDefinitions
-        , withItems
-        , withItem
         , withAdditionalItems
-        , withProperties
-        , withPatternProperties
         , withAdditionalProperties
-        , withSchemaDependency
-        , withPropNamesDependency
-        , withPropertyNames
         , withAllOf
         , withAnyOf
+        , withContains
+        , withDefinitions
+        , withItem
+        , withItems
+        , withNullableType
         , withOneOf
+        , withPatternProperties
+        , withPropNamesDependency
+        , withProperties
+        , withPropertyNames
+        , withSchemaDependency
         , withTitle
-        , withNot
+        , withType
+        , withUnionType
         )
 import Json.Schema.Definitions as Schema exposing (Schema, decoder)
-import Expect
-import Json.Encode as Encode exposing (Value)
-import Json.Decode as Decode exposing (decodeValue)
+import Test exposing (Test, describe, test)
+
+
+decodeValue : Decode.Decoder a -> Value -> Result String a
+decodeValue decoder value =
+    Decode.decodeValue decoder value
+        |> Result.mapError Decode.errorToString
 
 
 all : Test
@@ -81,10 +86,7 @@ all =
         , test "type=[null,integer]" <|
             \() ->
                 [ ( "type"
-                  , Encode.list
-                        [ Encode.string "null"
-                        , Encode.string "integer"
-                        ]
+                  , Encode.list Encode.string [ "null", "integer" ]
                   )
                 ]
                     |> decodesInto
@@ -94,10 +96,7 @@ all =
         , test "type=[string,integer]" <|
             \() ->
                 [ ( "type"
-                  , Encode.list
-                        [ Encode.string "integer"
-                        , Encode.string "string"
-                        ]
+                  , Encode.list Encode.string [ "integer", "string" ]
                   )
                 ]
                     |> decodesInto
@@ -120,7 +119,7 @@ all =
                         )
         , test "items=[blankSchema]" <|
             \() ->
-                [ ( "items", Encode.list <| [ Encode.object [] ] ) ]
+                [ ( "items", Encode.list Encode.object [ [] ] ) ]
                     |> decodesInto
                         (buildSchema
                             |> withItems [ buildSchema ]
@@ -176,7 +175,7 @@ all =
                         )
         , test "dependencies={foo=[bar]}" <|
             \() ->
-                [ ( "dependencies", Encode.object [ ( "foo", Encode.list [ Encode.string "bar" ] ) ] ) ]
+                [ ( "dependencies", Encode.object [ ( "foo", Encode.list Encode.string [ "bar" ] ) ] ) ]
                     |> decodesInto
                         (buildSchema
                             |> withPropNamesDependency "foo" [ "bar" ]
@@ -190,31 +189,31 @@ all =
                         )
         , test "enum=[]" <|
             \() ->
-                [ ( "enum", Encode.list [] ) ]
+                [ ( "enum", Encode.list Encode.object [] ) ]
                     |> decodeSchema
                     |> Expect.err
         , test "allOf=[]" <|
             \() ->
-                [ ( "allOf", Encode.list [] ) ]
+                [ ( "allOf", Encode.list Encode.object [] ) ]
                     |> decodeSchema
                     |> Expect.err
         , test "allOf=[blankSchema]" <|
             \() ->
-                [ ( "allOf", Encode.list [ Encode.object [] ] ) ]
+                [ ( "allOf", Encode.list Encode.object [ [] ] ) ]
                     |> decodesInto
                         (buildSchema
                             |> withAllOf [ buildSchema ]
                         )
         , test "oneOf=[blankSchema]" <|
             \() ->
-                [ ( "oneOf", Encode.list [ Encode.object [] ] ) ]
+                [ ( "oneOf", Encode.list Encode.object [ [] ] ) ]
                     |> decodesInto
                         (buildSchema
                             |> withOneOf [ buildSchema ]
                         )
         , test "anyOf=[blankSchema]" <|
             \() ->
-                [ ( "anyOf", Encode.list [ Encode.object [] ] ) ]
+                [ ( "anyOf", Encode.list Encode.object [ [] ] ) ]
                     |> decodesInto
                         (buildSchema
                             |> withAnyOf [ buildSchema ]
@@ -234,17 +233,9 @@ all =
         ]
 
 
-shouldResultWithSchema : Schema -> Result x Schema -> Expect.Expectation
-shouldResultWithSchema s =
-    s
-        |> Ok
-        |> Expect.equal
-
-
 decodeSchema : List ( String, Value ) -> Result String Schema
 decodeSchema list =
-    list
-        |> Encode.object
+    Encode.object list
         |> decodeValue Schema.decoder
 
 

--- a/tests/Draft4.elm
+++ b/tests/Draft4.elm
@@ -1,11 +1,11 @@
 module Draft4 exposing (all)
 
-import Json.Encode as Encode exposing (Value)
-import Json.Decode as Decode exposing (decodeString, value)
-import Json.Schema.Definitions exposing (blankSchema, decoder)
-import Json.Schema exposing (validateValue)
-import Test exposing (Test, describe, test, only)
 import Expect
+import Json.Decode exposing (decodeString, value)
+import Json.Encode as Encode
+import Json.Schema exposing (validateValue)
+import Json.Schema.Definitions exposing (blankSchema, decoder)
+import Test exposing (Test, describe, test)
 
 
 all : Test
@@ -5856,16 +5856,17 @@ examine schemaSource dataSource outcome =
 
         result =
             validateValue { applyDefaults = False } data schema
-                |> Result.mapError toString
+                |> Result.mapError Debug.toString
                 |> Result.map (\_ -> True)
     in
-        if outcome then
-            result
-                |> Expect.equal (Ok True)
-        else
-            case result of
-                Ok x ->
-                    Expect.fail "Unexpected success"
+    if outcome then
+        result
+            |> Expect.equal (Ok True)
 
-                Err _ ->
-                    Expect.pass
+    else
+        case result of
+            Ok _ ->
+                Expect.fail "Unexpected success"
+
+            Err _ ->
+                Expect.pass

--- a/tests/Draft6.elm
+++ b/tests/Draft6.elm
@@ -1,11 +1,11 @@
 module Draft6 exposing (all)
 
-import Json.Encode as Encode exposing (Value)
-import Json.Decode as Decode exposing (decodeString, value)
-import Json.Schema.Definitions exposing (blankSchema, decoder)
-import Json.Schema exposing (validateValue)
-import Test exposing (Test, describe, test, only)
 import Expect
+import Json.Decode as Decode
+import Json.Encode as Encode
+import Json.Schema exposing (validateValue)
+import Json.Schema.Definitions exposing (blankSchema, decoder)
+import Test exposing (Test, describe, test)
 
 
 all : Test
@@ -7267,26 +7267,27 @@ examine schemaSource dataSource outcome =
     let
         schema =
             schemaSource
-                |> decodeString decoder
+                |> Decode.decodeString decoder
                 |> Result.withDefault blankSchema
 
         data =
             dataSource
-                |> decodeString value
+                |> Decode.decodeString Decode.value
                 |> Result.withDefault Encode.null
 
         result =
             validateValue { applyDefaults = True } data schema
-                |> Result.mapError toString
+                |> Result.mapError Debug.toString
                 |> Result.map (\_ -> True)
     in
-        if outcome then
-            result
-                |> Expect.equal (Ok True)
-        else
-            case result of
-                Ok x ->
-                    Expect.fail "Unexpected success"
+    if outcome then
+        result
+            |> Expect.equal (Ok True)
 
-                Err _ ->
-                    Expect.pass
+    else
+        case result of
+            Ok _ ->
+                Expect.fail "Unexpected success"
+
+            Err _ ->
+                Expect.pass

--- a/tests/Generator.elm
+++ b/tests/Generator.elm
@@ -1,43 +1,23 @@
 module Generator exposing (all)
 
-import Test exposing (Test, describe, test, only)
+import Expect
+import Json.Encode as Encode
 import Json.Schema.Builder
     exposing
-        ( SchemaBuilder
-        , buildSchema
-        , boolSchema
+        ( buildSchema
         , toSchema
-        , withType
-        , withNullableType
-        , withUnionType
-        , withMinimum
-        , withMaximum
-        , withContains
-        , withDefinitions
-        , withItems
-        , withItem
-        , withMaxItems
-        , withMinItems
-        , withAdditionalItems
-        , withProperties
-        , withPatternProperties
-        , withAdditionalProperties
-        , withSchemaDependency
-        , withPropNamesDependency
-        , withPropertyNames
-        , withAllOf
-        , withAnyOf
-        , withOneOf
-        , withTitle
-        , withNot
-        , withExamples
         , withEnum
+        , withExamples
         )
-import Json.Schema.Definitions as Schema exposing (Schema, decoder, blankSchema)
+import Json.Schema.Definitions exposing (blankSchema)
 import Json.Schema.Random as JSR
-import Expect
-import Json.Encode as Encode exposing (Value)
 import Random exposing (initialSeed, step)
+import Test exposing (Test, describe, test)
+
+
+flip : (b -> a -> c) -> a -> b -> c
+flip f a b =
+    f b a
 
 
 all : Test
@@ -55,7 +35,7 @@ all =
                             , Encode.int 5
                             ]
                         |> toSchema
-                        |> Result.withDefault (blankSchema)
+                        |> Result.withDefault blankSchema
                         |> JSR.value JSR.defaultSettings
                         |> flip step (initialSeed 178)
                         |> (\( v, _ ) -> Expect.equal v (Encode.string "dime"))
@@ -64,7 +44,7 @@ all =
                     buildSchema
                         |> withExamples []
                         |> toSchema
-                        |> Result.withDefault (blankSchema)
+                        |> Result.withDefault blankSchema
                         |> JSR.value JSR.defaultSettings
                         |> flip step (initialSeed 178)
                         |> (\( v, _ ) -> Expect.equal v Encode.null)
@@ -81,7 +61,7 @@ all =
                             , Encode.int 5
                             ]
                         |> toSchema
-                        |> Result.withDefault (blankSchema)
+                        |> Result.withDefault blankSchema
                         |> JSR.value JSR.defaultSettings
                         |> flip step (initialSeed 178)
                         |> (\( v, _ ) -> Expect.equal v (Encode.string "dime"))
@@ -90,38 +70,41 @@ all =
                     buildSchema
                         |> withEnum []
                         |> toSchema
-                        |> Result.withDefault (blankSchema)
+                        |> Result.withDefault blankSchema
                         |> JSR.value JSR.defaultSettings
                         |> flip step (initialSeed 178)
                         |> (\( v, _ ) -> Expect.equal v Encode.null)
             ]
-        , describe "random object generation"
-            [ test "object with required fields" <|
-                \() ->
-                    buildSchema
-                        |> withProperties
-                            [ ( "foo", buildSchema |> withType "integer" ) ]
-                        |> toSchema
-                        |> Result.withDefault (blankSchema)
-                        |> JSR.value JSR.defaultSettings
-                        |> flip step (initialSeed 2)
-                        |> (\( v, _ ) -> Expect.equal v (Encode.object [ ( "foo", Encode.int 688281600 ) ]))
-            ]
-        , describe "random array generation"
-            [ test "list of similar items" <|
-                \() ->
-                    buildSchema
-                        |> withItem (buildSchema |> withType "integer" |> withMinimum 0 |> withMaximum 10)
-                        |> withMaxItems 10
-                        |> toSchema
-                        |> Result.withDefault (blankSchema)
-                        |> JSR.value JSR.defaultSettings
-                        |> flip step (initialSeed 1)
-                        |> (\( v, _ ) ->
-                                [ 3, 9, 7 ]
-                                    |> List.map Encode.int
-                                    |> Encode.list
-                                    |> Expect.equal v
-                           )
-            ]
+
+        -- , describe "random object generation"
+        -- [
+        -- We can no longer compare json values
+        -- These tests needs rewriting
+        --test "object with required fields" <|
+        --\() ->
+        --    buildSchema
+        --        |> withProperties
+        --            [ ( "foo", buildSchema |> withType "integer" ) ]
+        --        |> toSchema
+        --        |> Result.withDefault blankSchema
+        --        |> JSR.value JSR.defaultSettings
+        --        |> flip step (initialSeed 2)
+        --        |> (\( v, _ ) -> Expect.equal v (Encode.object [ ( "foo", Encode.int 688281600 ) ]))
+        -- ]
+        --, describe "random array generation"
+        --    [ test "list of similar items" <|
+        --        \() ->
+        --            buildSchema
+        --                |> withItem (buildSchema |> withType "integer" |> withMinimum 0 |> withMaximum 10)
+        --                |> withMaxItems 10
+        --                |> toSchema
+        --                |> Result.withDefault blankSchema
+        --                |> JSR.value JSR.defaultSettings
+        --                |> flip step (initialSeed 1)
+        --                |> (\( v, _ ) ->
+        --                        [ 3, 9, 7 ]
+        --                            |> Encode.list Encode.int
+        --                            |> Expect.equal v
+        --                   )
+        --    ]
         ]

--- a/tests/Validations.elm
+++ b/tests/Validations.elm
@@ -1,50 +1,50 @@
 module Validations exposing (all)
 
+import Expect
+import Json.Decode exposing (decodeValue)
+import Json.Encode as Encode exposing (int)
 import Json.Schema.Builder as JSB
     exposing
-        ( buildSchema
-        , boolSchema
-        , withItem
-        , withItems
+        ( boolSchema
+        , buildSchema
+        , validate
         , withAdditionalItems
-        , withContains
-        , withProperties
-        , withPatternProperties
         , withAdditionalProperties
-        , withSchemaDependency
-        , withPropNamesDependency
-        , withPropertyNames
-        , withType
-        , withNullableType
-        , withUnionType
         , withAllOf
         , withAnyOf
-        , withOneOf
-        , withMultipleOf
-        , withMaximum
-        , withMinimum
+        , withConst
+        , withContains
+        , withEnum
         , withExclusiveMaximum
         , withExclusiveMinimum
-        , withPattern
-        , withEnum
-        , withRequired
-        , withMaxLength
-        , withMinLength
-        , withMaxProperties
-        , withMinProperties
+        , withItem
+        , withItems
         , withMaxItems
+        , withMaxLength
+        , withMaxProperties
+        , withMaximum
         , withMinItems
+        , withMinLength
+        , withMinProperties
+        , withMinimum
+        , withMultipleOf
+        , withNullableType
+        , withOneOf
+        , withPattern
+        , withPatternProperties
+        , withPropNamesDependency
+        , withProperties
+        , withPropertyNames
+        , withRequired
+        , withSchemaDependency
+        , withType
+        , withUnionType
         , withUniqueItems
-        , withConst
-        , validate
         )
-import Json.Encode as Encode exposing (int)
-import Json.Decode as Decode exposing (decodeValue)
-import Json.Schema.Validation as Validation exposing (Error, defaultOptions, JsonPointer, ValidationError(..))
 import Json.Schema.Definitions exposing (blankSchema)
-import Test exposing (Test, describe, test, only)
+import Json.Schema.Validation as Validation exposing (Error, JsonPointer, ValidationError(..), defaultOptions)
 import Ref
-import Expect
+import Test exposing (Test, describe, test)
 
 
 all : Test
@@ -185,13 +185,13 @@ all =
                 \() ->
                     buildSchema
                         |> withItem (buildSchema |> withMaximum 10)
-                        |> JSB.validate defaultOptions (Encode.list [ int 1 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 1 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withItem (buildSchema |> withMaximum 10)
-                        |> JSB.validate defaultOptions (Encode.list [ int 1, int 11 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 1, 11 ])
                         |> Expect.equal (Err [ error [ "1" ] <| Maximum 10 11 ])
             ]
         , describe "items: array of schema"
@@ -204,7 +204,7 @@ all =
                             , buildSchema
                                 |> withMaximum 100
                             ]
-                        |> JSB.validate defaultOptions (Encode.list [ int 1, int 20 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 1, 20 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
@@ -215,7 +215,7 @@ all =
                             , buildSchema
                                 |> withMaximum 100
                             ]
-                        |> JSB.validate defaultOptions (Encode.list [ int 100, int 2 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 100, 2 ])
                         |> Expect.equal (Err [ error [ "0" ] <| Maximum 11 100 ])
             ]
         , describe "items: array of schema with additional items"
@@ -229,7 +229,7 @@ all =
                                 |> withMaximum 100
                             ]
                         |> withAdditionalItems (buildSchema |> withMaximum 1)
-                        |> JSB.validate defaultOptions (Encode.list [ int 1, int 20, int 1 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 1, 20, 1 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
@@ -241,7 +241,7 @@ all =
                                 |> withMaximum 100
                             ]
                         |> withAdditionalItems (buildSchema |> withMaximum 1)
-                        |> JSB.validate defaultOptions (Encode.list [ int 2, int 2, int 100 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 2, 2, 100 ])
                         |> Expect.equal (Err [ error [ "2" ] <| Maximum 1 100 ])
             ]
         , describe "maxItems"
@@ -249,13 +249,13 @@ all =
                 \() ->
                     buildSchema
                         |> withMaxItems 3
-                        |> validate defaultOptions (Encode.list [ int 1, int 2 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 2 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withMaxItems 2
-                        |> validate defaultOptions (Encode.list [ int 1, int 2, int 3 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 2, 3 ])
                         |> Expect.equal (Err [ error [] <| MaxItems 2 3 ])
             ]
         , describe "minItems"
@@ -263,13 +263,13 @@ all =
                 \() ->
                     buildSchema
                         |> withMinItems 2
-                        |> validate defaultOptions (Encode.list [ int 1, int 2, int 3 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 2, 3 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withMinItems 3
-                        |> validate defaultOptions (Encode.list [ int 1, int 2 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 2 ])
                         |> Expect.equal (Err [ error [] <| MinItems 3 2 ])
             ]
         , describe "uniqueItems"
@@ -277,13 +277,13 @@ all =
                 \() ->
                     buildSchema
                         |> withUniqueItems True
-                        |> validate defaultOptions (Encode.list [ int 1, int 2, int 3 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 2, 3 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withUniqueItems True
-                        |> validate defaultOptions (Encode.list [ int 1, int 1 ])
+                        |> validate defaultOptions (Encode.list Encode.int [ 1, 1 ])
                         |> Expect.equal (Err [ error [] <| UniqueItems (int 1) ])
             ]
         , describe "contains"
@@ -291,13 +291,13 @@ all =
                 \() ->
                     buildSchema
                         |> withContains (buildSchema |> withMaximum 1)
-                        |> JSB.validate defaultOptions (Encode.list [ int 10, int 20, int 1 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 10, 20, 1 ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withContains (buildSchema |> withMaximum 1)
-                        |> JSB.validate defaultOptions (Encode.list [ int 10, int 20 ])
+                        |> JSB.validate defaultOptions (Encode.list Encode.int [ 10, 20 ])
                         |> Expect.equal (Err [ error [] Contains ])
             ]
         , describe "maxProperties"
@@ -305,13 +305,13 @@ all =
                 \() ->
                     buildSchema
                         |> withMaxProperties 3
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withMaxProperties 1
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> Expect.equal (Err [ error [] <| MaxProperties 1 2 ])
             ]
         , describe "minProperties"
@@ -319,13 +319,13 @@ all =
                 \() ->
                     buildSchema
                         |> withMinProperties 1
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withMinProperties 3
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> Expect.equal (Err [ error [] <| MinProperties 3 2 ])
             ]
         , describe "required"
@@ -333,13 +333,13 @@ all =
                 \() ->
                     buildSchema
                         |> withRequired [ "foo", "bar" ]
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withRequired [ "foo", "bar" ]
-                        |> validate defaultOptions (Encode.object [ ( "foo", int 1 ) ])
+                        |> validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ) ])
                         |> Expect.equal (Err [ error [] <| Required [ "bar" ], error [ "bar" ] RequiredProperty ])
             ]
         , describe "properties"
@@ -350,7 +350,7 @@ all =
                             [ ( "foo", buildSchema |> withMaximum 10 )
                             , ( "bar", buildSchema |> withMaximum 20 )
                             ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
@@ -359,7 +359,7 @@ all =
                             [ ( "foo", buildSchema |> withMaximum 10 )
                             , ( "bar", buildSchema |> withMaximum 20 )
                             ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "bar", int 28 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "bar", Encode.int 28 ) ])
                         |> Expect.equal (Err [ error [ "bar" ] <| Maximum 20 28 ])
             ]
         , describe "patternProperties"
@@ -370,7 +370,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 10 )
                             , ( "a", buildSchema |> withMaximum 20 )
                             ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
@@ -379,7 +379,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 10 )
                             , ( "a", buildSchema |> withMaximum 20 )
                             ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "bar", int 28 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "bar", Encode.int 28 ) ])
                         |> Expect.equal (Err [ error [ "bar" ] <| Maximum 20 28 ])
             ]
         , describe "additionalProperties"
@@ -390,7 +390,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (buildSchema |> withMaximum 20)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "success: props" <|
                 \() ->
@@ -399,7 +399,7 @@ all =
                             [ ( "foo", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (buildSchema |> withMaximum 20)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "success: boolean true" <|
                 \() ->
@@ -408,7 +408,7 @@ all =
                             [ ( "foo", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (boolSchema True)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
@@ -417,7 +417,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (buildSchema |> withMaximum 20)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ), ( "bar", int 200 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ), ( "bar", Encode.int 200 ) ])
                         |> Expect.equal (Err [ error [ "bar" ] <| Maximum 20 200 ])
             , test "success: boolean false" <|
                 \() ->
@@ -426,7 +426,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (boolSchema False)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ) ])
                         |> expectOk
             , test "failure: boolean false" <|
                 \() ->
@@ -435,7 +435,7 @@ all =
                             [ ( "o{2}", buildSchema |> withMaximum 100 )
                             ]
                         |> withAdditionalProperties (boolSchema False)
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 100 ), ( "bar", int 200 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 100 ), ( "bar", Encode.int 200 ) ])
                         |> Expect.equal (Err [ error [] <| AdditionalPropertiesDisallowed [ "bar" ], error [ "bar" ] AdditionalPropertyDisallowed ])
             ]
         , describe "dependencies"
@@ -445,7 +445,7 @@ all =
                         |> withSchemaDependency
                             "foo"
                             (buildSchema |> withRequired [ "bar" ])
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure when dependency is a schema" <|
                 \() ->
@@ -453,14 +453,15 @@ all =
                         |> withSchemaDependency
                             "foo"
                             (buildSchema |> withRequired [ "bar" ])
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ) ])
                         |> Expect.equal (Err [ error [] <| Required [ "bar" ], error [ "bar" ] RequiredProperty ])
-              --|> Expect.equal (Err "Required property 'bar' is missing")
+
+            --|> Expect.equal (Err "Required property 'bar' is missing")
             , test "failure when dependency is array of strings" <|
                 \() ->
                     buildSchema
                         |> withPropNamesDependency "foo" [ "bar" ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ) ])
                         |> Expect.equal (Err [ error [] <| Required [ "bar" ], error [ "bar" ] RequiredProperty ])
             ]
         , describe "propertyNames"
@@ -468,26 +469,26 @@ all =
                 \() ->
                     buildSchema
                         |> withPropertyNames (buildSchema |> withPattern "^ba")
-                        |> JSB.validate defaultOptions (Encode.object [ ( "baz", int 1 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "baz", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
                         |> withPropertyNames (buildSchema |> withPattern "^ba")
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 1 ), ( "bar", int 2 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 1 ), ( "bar", Encode.int 2 ) ])
                         |> Expect.equal (Err [ error [] <| InvalidPropertyName [ error [ "foo" ] <| Pattern "^ba" "foo" ] ])
             ]
         , describe "enum"
             [ test "success" <|
                 \() ->
                     buildSchema
-                        |> withEnum [ int 1, int 2 ]
+                        |> withEnum [ Encode.int 1, Encode.int 2 ]
                         |> validate defaultOptions (Encode.int 2)
                         |> expectOk
             , test "failure" <|
                 \() ->
                     buildSchema
-                        |> withEnum [ int 1, int 2 ]
+                        |> withEnum [ Encode.int 1, Encode.int 2 ]
                         |> validate defaultOptions (Encode.int 3)
                         |> Expect.equal (Err [ error [] Enum ])
             ]
@@ -517,7 +518,7 @@ all =
                     buildSchema
                         |> withType "string"
                         |> JSB.validate defaultOptions (Encode.int 1)
-                        |> Expect.equal (Err [ error [] <| InvalidType "Expecting a String but instead got: 1" ])
+                        |> Expect.equal (Err [ error [] <| typeError "STRING" "1" ])
             ]
         , describe "type=number"
             [ test "success" <|
@@ -531,13 +532,13 @@ all =
                     buildSchema
                         |> withType "number"
                         |> JSB.validate defaultOptions (Encode.string "bar")
-                        |> Expect.equal (Err [ error [] <| InvalidType "Expecting a Float but instead got: \"bar\"" ])
+                        |> Expect.equal (Err [ error [] <| typeError "FLOAT" "\"bar\"" ])
             , test "failure with null" <|
                 \() ->
                     buildSchema
                         |> withType "number"
                         |> JSB.validate defaultOptions Encode.null
-                        |> Expect.equal (Err [ error [] <| InvalidType "Expecting a Float but instead got: null" ])
+                        |> Expect.equal (Err [ error [] <| typeError "FLOAT" "null" ])
             ]
         , describe "type=null,number"
             [ test "success" <|
@@ -557,7 +558,7 @@ all =
                     buildSchema
                         |> withNullableType "number"
                         |> JSB.validate defaultOptions (Encode.string "bar")
-                        |> Expect.equal (Err [ error [] <| InvalidType "Expecting a Float but instead got: \"bar\"" ])
+                        |> Expect.equal (Err [ error [] <| typeError "FLOAT" "\"bar\"" ])
             ]
         , describe "type=number,string"
             [ test "success for number" <|
@@ -614,7 +615,7 @@ all =
                     buildSchema
                         |> withAllOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int 1)
                         |> expectOk
@@ -623,7 +624,7 @@ all =
                     buildSchema
                         |> withAnyOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.float 0.5)
                         |> expectOk
@@ -632,7 +633,7 @@ all =
                     buildSchema
                         |> withAnyOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int -1)
                         |> Expect.equal
@@ -648,7 +649,7 @@ all =
                     buildSchema
                         |> withOneOf
                             [ buildSchema |> withMinimum 10
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int 1)
                         |> expectOk
@@ -657,7 +658,7 @@ all =
                     buildSchema
                         |> withOneOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int 0)
                         |> expectOk
@@ -666,7 +667,7 @@ all =
                     buildSchema
                         |> withOneOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int -1)
                         |> Expect.equal (Err [ error [] OneOfNoneSucceed ])
@@ -675,7 +676,7 @@ all =
                     buildSchema
                         |> withOneOf
                             [ buildSchema |> withMinimum 0
-                            , buildSchema |> withEnum [ int 1 ]
+                            , buildSchema |> withEnum [ Encode.int 1 ]
                             ]
                         |> JSB.validate defaultOptions (Encode.int 1)
                         |> Expect.equal (Err [ error [] <| OneOfManySucceed 2 ])
@@ -704,11 +705,11 @@ all =
                             [ ( "foo", buildSchema |> withMaximum 1 )
                             , ( "bar", buildSchema |> withMaximum 2 )
                             ]
-                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", int 7 ), ( "bar", int 28 ) ])
+                        |> JSB.validate defaultOptions (Encode.object [ ( "foo", Encode.int 7 ), ( "bar", Encode.int 28 ) ])
                         |> Expect.equal
                             (Err
-                                [ error [ "foo" ] <| Maximum 1 7
-                                , error [ "bar" ] <| Maximum 2 28
+                                [ error [ "bar" ] <| Maximum 2 28
+                                , error [ "foo" ] <| Maximum 1 7
                                 ]
                             )
             ]
@@ -717,30 +718,45 @@ all =
                 \() ->
                     buildSchema
                         |> withProperties
-                            [ ( "key", buildSchema
-                                |> withType "string"
-                                |> JSB.withDefault (Encode.string "def")
-                            ) ]
+                            [ ( "key"
+                              , buildSchema
+                                    |> withType "string"
+                                    |> JSB.withDefault (Encode.string "def")
+                              )
+                            ]
                         |> JSB.validate { applyDefaults = True } (Encode.object [])
                         |> Expect.equal
-                            (Ok <| Encode.object [ ("key", Encode.string  "def" ) ])
+                            (Ok <| Encode.object [ ( "key", Encode.string "def" ) ])
             , test "apply default value in nested object" <|
                 \() ->
                     buildSchema
                         |> withProperties
-                            [ ( "obj", buildSchema
-                                |> withProperties
-                                    [ ( "key", buildSchema
-                                        |> withType "string"
-                                        |> JSB.withDefault (Encode.string "def")
-                                    ) ]
-                            ) ]
+                            [ ( "obj"
+                              , buildSchema
+                                    |> withProperties
+                                        [ ( "key"
+                                          , buildSchema
+                                                |> withType "string"
+                                                |> JSB.withDefault (Encode.string "def")
+                                          )
+                                        ]
+                              )
+                            ]
                         |> JSB.validate { applyDefaults = True } (Encode.object [])
                         |> Result.map (Encode.encode 0)
                         |> Expect.equal
                             (Ok """{"obj":{"key":"def"}}""")
             ]
         ]
+
+
+typeError : String -> String -> ValidationError
+typeError type_ value =
+    InvalidType <| """Problem with the given value:
+
+""" ++ value ++ """
+
+Expecting a """ ++ type_
 
 
 error : List String -> ValidationError -> Error
@@ -752,7 +768,7 @@ expectOk : Result x a -> Expect.Expectation
 expectOk e =
     case e of
         Err x ->
-            Expect.fail <| "Unexpected error: " ++ (toString x)
+            Expect.fail <| "Unexpected error: " ++ Debug.toString x
 
         Ok _ ->
             Expect.pass


### PR DESCRIPTION
A few tests were not running when I updated to Elm 0.19.1. I didn't check if they were also broken in the previous version. I was mainly changing how Encode.list works I think. There were two tests that depend on comparing Json.Encode.Value which now show as <internals> and cannot be compared. I have commented these out, maybe you can think of a way to rewrite them, I have not yet given that much thought. 

In addition my editor shows me elm-analyse errors, so I removed some code (and a few debug log comments) and rewrote a couple of bits to silence those warnings. One remaining error is for `ValidationOptions` which has only one boolean value, analyse wants to get rid of the object but I left it in. 